### PR TITLE
BUGFIX: Allow to configure Imagick resource limits

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,6 @@
+preset: psr2
+
+finder:
+  path:
+    - "Classes"
+    - "Tests"

--- a/Classes/TYPO3/Imagine/ImagineFactory.php
+++ b/Classes/TYPO3/Imagine/ImagineFactory.php
@@ -98,7 +98,7 @@ class ImagineFactory extends AbstractImagineFactory
             return;
         }
 
-        $limits = $this->settings['driverSpecific']['Imagick']['limits'] ?? [];
+        $limits = $this->settings['driverSpecific']['Imagick']['limits'] ? $this->settings['driverSpecific']['Imagick']['limits'] : [];
         foreach ($limits as $resourceType => $limit) {
             \Imagick::setResourceLimit($resourceType, $limit);
         }

--- a/Classes/TYPO3/Imagine/ImagineFactory.php
+++ b/Classes/TYPO3/Imagine/ImagineFactory.php
@@ -41,6 +41,8 @@ class ImagineFactory extends AbstractImagineFactory {
 	 * @api
 	 */
 	public function create($className = 'Imagine') {
+		$this->configureDriverSpecificSettings();
+
 		$className = 'Imagine\\' . $this->settings['driver'] . '\\' . $className;
 		$arguments = array_slice(func_get_args(), 1);
 
@@ -56,7 +58,30 @@ class ImagineFactory extends AbstractImagineFactory {
 				$class = new \ReflectionClass($className);
 				$object =  $class->newInstanceArgs($arguments);
 		}
+
 		return $object;
 	}
 
+	/**
+	 * Set driver specific settings.
+	 */
+	protected function configureDriverSpecificSettings() {
+		if ($this->settings['driver'] === 'Imagick') {
+			$this->configureImagickSettings();
+		}
+	}
+
+	/**
+	 * Sets limits for the Imagick driver.
+	 */
+	protected function configureImagickSettings() {
+		if (!isset($this->settings['driverSpecific']['Imagick'])) {
+			return;
+		}
+
+		$limits = $this->settings['driverSpecific']['Imagick']['limits'] ?? [];
+		foreach ($limits as $resourceType => $limit) {
+			\Imagick::setResourceLimit($resourceType, $limit);
+		}
+	}
 }

--- a/Classes/TYPO3/Imagine/ImagineFactory.php
+++ b/Classes/TYPO3/Imagine/ImagineFactory.php
@@ -20,34 +20,34 @@ use TYPO3\Flow\Annotations as Flow;
  */
 class ImagineFactory extends AbstractImagineFactory
 {
-	/**
+    /**
      * @Flow\Inject
-	 * @var \TYPO3\Flow\Object\ObjectManagerInterface
-	 */
-	protected $objectManager;
+     * @var \TYPO3\Flow\Object\ObjectManagerInterface
+     */
+    protected $objectManager;
 
-	/**
-	 * Factory method which creates an Imagine instance.
-	 *
-	 * By default this factory creates an Imagine service according to the currently configured driver (for example GD
-	 * or ImageMagick).
-	 *
-	 * You may alternatively specify a class name of a driver-dependent class you need an instance of. For example,
-	 * specifying "Image" with the currently configured driver "Gd" will return an instance of the class
-	 * \Imagine\Gd\Image.
-	 *
-	 * @param string $className If specified, this factory will create an instance of the driver dependent class
-	 * @return \Imagine\Image\ImagineInterface
-	 * @api
-	 */
+    /**
+     * Factory method which creates an Imagine instance.
+     *
+     * By default this factory creates an Imagine service according to the currently configured driver (for example GD
+     * or ImageMagick).
+     *
+     * You may alternatively specify a class name of a driver-dependent class you need an instance of. For example,
+     * specifying "Image" with the currently configured driver "Gd" will return an instance of the class
+     * \Imagine\Gd\Image.
+     *
+     * @param string $className If specified, this factory will create an instance of the driver dependent class
+     * @return \Imagine\Image\ImagineInterface
+     * @api
+     */
     public function create($className = 'Imagine')
     {
-		$this->configureDriverSpecificSettings();
+        $this->configureDriverSpecificSettings();
 
-		$className = 'Imagine\\' . $this->settings['driver'] . '\\' . $className;
-		$arguments = array_slice(func_get_args(), 1);
+        $className = 'Imagine\\' . $this->settings['driver'] . '\\' . $className;
+        $arguments = array_slice(func_get_args(), 1);
 
-		switch (count($arguments)) {
+        switch (count($arguments)) {
             case 0:
                 $object = new $className();
                 break;
@@ -69,38 +69,38 @@ class ImagineFactory extends AbstractImagineFactory
             case 6:
                 $object = new $className($arguments[0], $arguments[1], $arguments[2], $arguments[3], $arguments[4], $arguments[5]);
                 break;
-			default:
-				$class = new \ReflectionClass($className);
+            default:
+                $class = new \ReflectionClass($className);
                 $object = $class->newInstanceArgs($arguments);
-		}
+        }
 
-		return $object;
-	}
+        return $object;
+    }
 
-	/**
-	 * Set driver specific settings.	 
-	 *
-	 * @return void
-	 */
-	protected function configureDriverSpecificSettings() {
-		if ($this->settings['driver'] === 'Imagick') {
-			$this->configureImagickSettings();
-		}
-	}
+    /**
+     * Set driver specific settings.     
+     *
+     * @return void
+     */
+    protected function configureDriverSpecificSettings() {
+        if ($this->settings['driver'] === 'Imagick') {
+            $this->configureImagickSettings();
+        }
+    }
 
-	/**
-	 * Sets limits for the Imagick driver.
-	 *
-	 * @return void
-	 */
-	protected function configureImagickSettings() {
-		if (!isset($this->settings['driverSpecific']['Imagick'])) {
-			return;
-		}
+    /**
+     * Sets limits for the Imagick driver.
+     *
+     * @return void
+     */
+    protected function configureImagickSettings() {
+        if (!isset($this->settings['driverSpecific']['Imagick'])) {
+            return;
+        }
 
-		$limits = $this->settings['driverSpecific']['Imagick']['limits'] ?? [];
-		foreach ($limits as $resourceType => $limit) {
-			\Imagick::setResourceLimit($resourceType, $limit);
-		}
-	}
+        $limits = $this->settings['driverSpecific']['Imagick']['limits'] ?? [];
+        foreach ($limits as $resourceType => $limit) {
+            \Imagick::setResourceLimit($resourceType, $limit);
+        }
+    }
 }

--- a/Classes/TYPO3/Imagine/ImagineFactory.php
+++ b/Classes/TYPO3/Imagine/ImagineFactory.php
@@ -63,7 +63,9 @@ class ImagineFactory extends AbstractImagineFactory {
 	}
 
 	/**
-	 * Set driver specific settings.
+	 * Set driver specific settings.	 
+	 *
+	 * @return void
 	 */
 	protected function configureDriverSpecificSettings() {
 		if ($this->settings['driver'] === 'Imagick') {
@@ -73,6 +75,8 @@ class ImagineFactory extends AbstractImagineFactory {
 
 	/**
 	 * Sets limits for the Imagick driver.
+	 *
+	 * @return void
 	 */
 	protected function configureImagickSettings() {
 		if (!isset($this->settings['driverSpecific']['Imagick'])) {

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -5,3 +5,9 @@ TYPO3:
       'RGB': 'color.org/sRGB_IEC61966-2-1_black_scaled.icc'
       'CMYK': 'Adobe/CMYK/USWebUncoated.icc'
       'Grayscale': 'colormanagement.org/ISOcoated_v2_grey1c_bas.ICC'
+    driverSpecific:
+      Imagick:
+        # define a map of limits, where the key is an int (one of the "IMagick::RESOURCETYPE_*" constants)
+        # and the value is the limit in bytes for that resource.
+        # For details see \Imagick::setResourceLimit()
+        limits: []

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -7,7 +7,7 @@ TYPO3:
       'Grayscale': 'colormanagement.org/ISOcoated_v2_grey1c_bas.ICC'
     driverSpecific:
       Imagick:
-        # define a map of limits, where the key is an int (one of the "IMagick::RESOURCETYPE_*" constants)
+        # define a map of limits, where the key is an int (one of the "Imagick::RESOURCETYPE_*" constants)
         # and the value is the limit in bytes for that resource.
         # For details see \Imagick::setResourceLimit()
         limits: []


### PR DESCRIPTION
In order to be able to run in confined server environments a resource
limit for Imagick can be configured now as otherwise Imagick is very
generous in it's resource usage.