### PR TITLE
Revert "BUGFIX: Change the dependency to accept 0.* versions of imagine"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "neos/flow": "~4.0 || dev-master",
-        "imagine/Imagine": "~0.7"
+        "imagine/Imagine": "0.6.*"
     },
     "replace": {
         "typo3/imagine": "self.version"


### PR DESCRIPTION
Reverts neos/imagine#5 as imagine 0.7 currently is not compatible with PHP 7.0.