### PR TITLE
BUGFIX: Keep settings in memory

### DIFF
--- a/Classes/AbstractImagineFactory.php
+++ b/Classes/AbstractImagineFactory.php
@@ -35,8 +35,8 @@ class AbstractImagineFactory
      */
     public function injectSettings(array $settings)
     {
-        $this->settings = $settings;
-        if (!in_array($settings['driver'], array_keys(array_filter($settings['enabledDrivers'])), true)) {
+        $this->settings = \array_merge($this->settings, $settings);
+        if (!array_key_exists($this->settings['driver'], array_filter($this->settings['enabledDrivers']))) {
             throw new \InvalidArgumentException('The "driver" setting for Imagine must enable by setting, check Neos.Imagine.enabledDrivers.', 1515402616);
         }
     }

--- a/Classes/AbstractImagineFactory.php
+++ b/Classes/AbstractImagineFactory.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Neos\Imagine;
 
 /*

--- a/Classes/AbstractImagineFactory.php
+++ b/Classes/AbstractImagineFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Imagine;
 
 /*
@@ -18,8 +19,7 @@ use Neos\Flow\Annotations as Flow;
  *
  * @Flow\Scope("singleton")
  */
-class AbstractImagineFactory
-{
+class AbstractImagineFactory {
 
     /**
      * @var array
@@ -33,8 +33,7 @@ class AbstractImagineFactory
      * @return void
      * @throws \InvalidArgumentException
      */
-    public function injectSettings(array $settings)
-    {
+    public function injectSettings(array $settings) {
         $this->settings = \array_merge($this->settings, $settings);
         if (!array_key_exists($this->settings['driver'], array_filter($this->settings['enabledDrivers']))) {
             throw new \InvalidArgumentException('The "driver" setting for Imagine must enable by setting, check Neos.Imagine.enabledDrivers.', 1515402616);

--- a/Classes/AbstractImagineFactory.php
+++ b/Classes/AbstractImagineFactory.php
@@ -19,7 +19,8 @@ use Neos\Flow\Annotations as Flow;
  *
  * @Flow\Scope("singleton")
  */
-class AbstractImagineFactory {
+class AbstractImagineFactory
+{
 
     /**
      * @var array
@@ -33,7 +34,8 @@ class AbstractImagineFactory {
      * @return void
      * @throws \InvalidArgumentException
      */
-    public function injectSettings(array $settings) {
+    public function injectSettings(array $settings)
+    {
         $this->settings = \array_merge($this->settings, $settings);
         if (!array_key_exists($this->settings['driver'], array_filter($this->settings['enabledDrivers']))) {
             throw new \InvalidArgumentException('The "driver" setting for Imagine must enable by setting, check Neos.Imagine.enabledDrivers.', 1515402616);


### PR DESCRIPTION
It can happen that the injectSettings method is called multiple
times and that the result differs. So the singleton should use the
class property. So this patch merges the class property with
the incoming settings and always uses the class property instead
of the local variable.

This was also mentioned in a ticket: 
https://github.com/neos/neos-development-collection/issues/1872

Fixes: #1872