### PR TITLE
BUGFIX: Keep settings in memory

### DIFF
--- a/Classes/AbstractImagineFactory.php
+++ b/Classes/AbstractImagineFactory.php
@@ -35,12 +35,8 @@ class AbstractImagineFactory
      */
     public function injectSettings(array $settings)
     {
-        $this->settings = $settings;
-        if (!isset($settings['enabledDrivers'])) {
-            // FIXME: This is a hotfix and should actually be fixed in the Neos setup step. As soon as it is fixed there, this condition can be removed.
-            return;
-        }
-        if (!in_array($settings['driver'], array_keys(array_filter($settings['enabledDrivers'])), true)) {
+        $this->settings = \array_merge($this->settings, $settings);
+        if (!array_key_exists($this->settings['driver'], array_filter($this->settings['enabledDrivers']))) {
             throw new \InvalidArgumentException('The "driver" for Imagine must be enabled by settings, check Neos.Imagine.enabledDrivers.', 1515402616);
         }
     }


### PR DESCRIPTION
It can happen that the injectSettings method is called multiple
times and that the result differs. So the singleton should use the
class property. So this patch merges the class property with
the incoming settings and always uses the class property instead
of the local variable.

Fixes: #1872