### PR TITLE
TASK: Allow arbitrary `driver` values in YAML schema

### DIFF
--- a/Classes/ImagineFactory.php
+++ b/Classes/ImagineFactory.php
@@ -20,7 +20,6 @@ use Neos\Flow\Annotations as Flow;
  */
 class ImagineFactory extends AbstractImagineFactory
 {
-
     /**
      * @var \Neos\Flow\ObjectManagement\ObjectManagerInterface
      * @Flow\Inject
@@ -39,6 +38,7 @@ class ImagineFactory extends AbstractImagineFactory
      *
      * @param string $className If specified, this factory will create an instance of the driver dependent class
      * @return \Imagine\Image\ImagineInterface
+     * @throws \ReflectionException
      * @api
      */
     public function create($className = 'Imagine')
@@ -60,6 +60,7 @@ class ImagineFactory extends AbstractImagineFactory
                 $class = new \ReflectionClass($className);
                 $object =  $class->newInstanceArgs($arguments);
         }
+
         return $object;
     }
 
@@ -68,7 +69,8 @@ class ImagineFactory extends AbstractImagineFactory
      *
      * @return void
      */
-    protected function configureDriverSpecificSettings() {
+    protected function configureDriverSpecificSettings()
+    {
         if ($this->settings['driver'] === 'Imagick') {
             $this->configureImagickSettings();
         }
@@ -79,7 +81,8 @@ class ImagineFactory extends AbstractImagineFactory
      *
      * @return void
      */
-    protected function configureImagickSettings() {
+    protected function configureImagickSettings()
+    {
         if (!isset($this->settings['driverSpecific']['Imagick'])) {
             return;
         }

--- a/Resources/Private/Schema/Settings/Neos.Imagine.driver.schema.yaml
+++ b/Resources/Private/Schema/Settings/Neos.Imagine.driver.schema.yaml
@@ -1,3 +1,2 @@
 type: string
 required: TRUE
-enum: [ 'Gd', 'Imagick', 'Gmagick' ]


### PR DESCRIPTION
There might be other driver types available, and the schema is not the
place to check this.