### PR TITLE
BUGFIX: Set correct path for profiles

### DIFF
--- a/Classes/Aspect/PaletteInterfaceAspect.php
+++ b/Classes/Aspect/PaletteInterfaceAspect.php
@@ -102,7 +102,7 @@ class PaletteInterfaceAspect
     protected function createAndSetProfileOnProxy(PaletteInterface $proxy, $profilePath)
     {
         if (substr($profilePath, 0, 11) !== 'resource://') {
-            $profilePath = $this->packageManager->getPackage('imagine.imagine')->getPackagePath() . 'lib/Imagine/resources/' . $profilePath;
+            $profilePath = $this->packageManager->getPackage('imagine.imagine')->getPackagePath() . 'src/resources/' . $profilePath;
         }
         $profile = Profile::fromPath($profilePath);
         ObjectAccess::setProperty($proxy, 'profile', $profile, true);


### PR DESCRIPTION
This will close https://github.com/neos/neos-development-collection/issues/3827

In `Neos.Imagine/Classes/Aspect/PaletteInterfaceAspect.php` there is the path defined, where the default profiles are located. Currently, the path is set to 

`$profilePath = $this->packageManager->getPackage('imagine.imagine')->getPackagePath() . 'lib/Imagine/resources/' . $profilePath;`

But in the imagine package, the profiles are stored under `src/resources`, so the path should be defined as followed:

`$profilePath = $this->packageManager->getPackage('imagine.imagine')->getPackagePath() . 'src/resources/' . $profilePath;`

This is broken since version 1 of `imagine/imagine`

Look at the last line of the release notes: https://github.com/php-imagine/Imagine/releases/tag/1.0.0-alpha1